### PR TITLE
Bugfix/Update redirect URL after successful patient registration

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -170,7 +170,7 @@ async function sendRegisterRequest(
       icon: 'success',
       confirmButtonText: 'OK',
     })
-    window.location.href = '/login'
+    window.location.href = '/register'
   } else {
     const errorMessage = extractErrorMessage(responseData, 'Registrasi gagal')
     await Swal.fire({


### PR DESCRIPTION
This pull request makes a minor change to the registration flow by updating the redirect after a successful registration. Instead of sending users to the login page, they are now redirected to the registration page.

* Changed the redirect in `sendRegisterRequest` in `src/app/register/page.tsx` to send users to `/register` instead of `/login` after successful registration.