### PR TITLE
Feature/Implement fix checkbox for treatment on edit treatment

### DIFF
--- a/src/app/_components/__tests__/selectTreatmentCondition.test.tsx
+++ b/src/app/_components/__tests__/selectTreatmentCondition.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { TreatmentConditionMultiSelect } from '../selectTreatmentCondition'
+
+describe('TreatmentConditionMultiSelect', () => {
+  describe('Browser mode (native select multiple)', () => {
+    test('renders native select element in browser mode', () => {
+      const mockOnChange = jest.fn()
+      render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={[]}
+          onChange={mockOnChange}
+        />
+      )
+
+      const selectElement = screen.getByTestId('test-select')
+      expect(selectElement).toBeInTheDocument()
+      expect(selectElement.tagName).toBe('SELECT')
+      expect(selectElement).toHaveAttribute('multiple')
+    })
+
+    test('renders all treatment condition options', () => {
+      const mockOnChange = jest.fn()
+      render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={[]}
+          onChange={mockOnChange}
+        />
+      )
+
+      // Check for a few key options
+      expect(screen.getByText('Tit Tar (TT)')).toBeInTheDocument()
+      expect(screen.getByText('Massage Gun (MG)')).toBeInTheDocument()
+      expect(screen.getByText('Chiro Gun (CG)')).toBeInTheDocument()
+      expect(screen.getByText('Dry Needling (DN)')).toBeInTheDocument()
+    })
+
+    test('displays selected values correctly', () => {
+      const mockOnChange = jest.fn()
+      render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={['TT', 'MG']}
+          onChange={mockOnChange}
+        />
+      )
+
+      const selectElement = screen.getByTestId(
+        'test-select'
+      ) as HTMLSelectElement
+      const selectedOptions = Array.from(selectElement.selectedOptions).map(
+        (opt) => opt.value
+      )
+
+      expect(selectedOptions).toEqual(['TT', 'MG'])
+    })
+
+    test('calls onChange when selection changes', () => {
+      const mockOnChange = jest.fn()
+      render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={[]}
+          onChange={mockOnChange}
+        />
+      )
+
+      const selectElement = screen.getByTestId(
+        'test-select'
+      ) as HTMLSelectElement
+
+      // Get the actual options from the select element
+      const options = selectElement.options
+
+      // Select the first two options (TT and MG)
+      options[0].selected = true
+      options[1].selected = true
+
+      // Trigger the change event
+      fireEvent.change(selectElement)
+
+      expect(mockOnChange).toHaveBeenCalledWith(['TT', 'MG'])
+    })
+
+    test('respects disabled prop', () => {
+      const mockOnChange = jest.fn()
+      render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={[]}
+          onChange={mockOnChange}
+          disabled={true}
+        />
+      )
+
+      const selectElement = screen.getByTestId('test-select')
+      expect(selectElement).toBeDisabled()
+    })
+
+    test('updates when value prop changes', () => {
+      const mockOnChange = jest.fn()
+      const { rerender } = render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={['TT']}
+          onChange={mockOnChange}
+        />
+      )
+
+      let selectElement = screen.getByTestId('test-select') as HTMLSelectElement
+      let selectedOptions = Array.from(selectElement.selectedOptions).map(
+        (opt) => opt.value
+      )
+      expect(selectedOptions).toEqual(['TT'])
+
+      // Update value prop
+      rerender(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={['MG', 'CG']}
+          onChange={mockOnChange}
+        />
+      )
+
+      selectElement = screen.getByTestId('test-select') as HTMLSelectElement
+      selectedOptions = Array.from(selectElement.selectedOptions).map(
+        (opt) => opt.value
+      )
+      expect(selectedOptions).toEqual(['MG', 'CG'])
+    })
+
+    test('handles empty value prop', () => {
+      const mockOnChange = jest.fn()
+      render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={[]}
+          onChange={mockOnChange}
+        />
+      )
+
+      const selectElement = screen.getByTestId(
+        'test-select'
+      ) as HTMLSelectElement
+      expect(selectElement.selectedOptions.length).toBe(0)
+    })
+
+    test('handles undefined value prop', () => {
+      const mockOnChange = jest.fn()
+      render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          onChange={mockOnChange}
+        />
+      )
+
+      const selectElement = screen.getByTestId(
+        'test-select'
+      ) as HTMLSelectElement
+      expect(selectElement.selectedOptions.length).toBe(0)
+    })
+
+    test('renders all 14 treatment condition options', () => {
+      const mockOnChange = jest.fn()
+      render(
+        <TreatmentConditionMultiSelect
+          id="test-select"
+          label="Test Label"
+          value={[]}
+          onChange={mockOnChange}
+        />
+      )
+
+      const selectElement = screen.getByTestId(
+        'test-select'
+      ) as HTMLSelectElement
+      // Should have 14 options based on TreatmentConditionOptions
+      expect(selectElement.options.length).toBe(14)
+    })
+  })
+})

--- a/src/app/_components/selectTreatmentCondition.tsx
+++ b/src/app/_components/selectTreatmentCondition.tsx
@@ -17,18 +17,14 @@ export function TreatmentConditionMultiSelect({
   onChange,
   disabled,
 }: MultiSelectProps) {
-  const [selected, setSelected] = React.useState<string[]>(propValue ?? [])
-
-  React.useEffect(() => {
-    setSelected(propValue ?? [])
-  }, [propValue])
+  // Fully controlled component - no internal state
+  const selected = propValue ?? []
 
   const handleNativeSelectChange = (
     e: React.ChangeEvent<HTMLSelectElement>
   ) => {
     const options = Array.from(e.target.options)
     const values = options.filter((o) => o.selected).map((o) => o.value)
-    setSelected(values)
     onChange(values)
   }
 
@@ -37,7 +33,6 @@ export function TreatmentConditionMultiSelect({
     const next = checked
       ? [...selected, optionId]
       : selected.filter((s) => s !== optionId)
-    setSelected(next)
     onChange(next)
   }
 
@@ -48,6 +43,8 @@ export function TreatmentConditionMultiSelect({
   if (isBrowser) {
     return (
       <div className="w-full">
+        {/* Label is sr-only for accessibility. Parent components must provide 
+            their own visible label element to inform sighted users what they're selecting. */}
         <label htmlFor={id} className="sr-only">
           {label}
         </label>

--- a/src/app/_components/treatmentForm.tsx
+++ b/src/app/_components/treatmentForm.tsx
@@ -26,6 +26,8 @@ export function TreatmentForm({
   setTherapistIDState,
 }: TreatmentFormProps) {
   const isTherapistRole = isTherapist()
+  // The backend may return treatment data in either JSON array format or comma-separated string format.
+  // This function handles both formats to ensure compatibility with different API versions or data states.
   const parseTreatmentToArray = (raw: string | undefined): string[] => {
     if (!raw) return []
     try {
@@ -163,6 +165,8 @@ export function TreatmentForm({
               onResizeCapture={undefined}
             />
             <div>
+              {/* Treatment selection should remain editable for all roles,
+                  including therapists, per business requirements. */}
               <TreatmentConditionMultiSelect
                 id="treatmentHistory"
                 label="Penanganan"

--- a/src/app/treatment/register/page.tsx
+++ b/src/app/treatment/register/page.tsx
@@ -22,18 +22,13 @@ let nextVisitInput: HTMLInputElement | null = null
 
 export default function RegisterTreatment() {
   const [therapistID, setTherapistID] = useState<string>('')
-  const [treatmentHistoryItems, setTreatmentHistoryItems] = useState<string[]>(
-    []
-  )
+  const [selectedTreatmentConditions, setSelectedTreatmentConditions] =
+    useState<string[]>([])
 
   // Keep the module-scoped `treatmentHistoryInput` in sync for legacy code paths
   React.useEffect(() => {
-    treatmentHistoryInput = treatmentHistoryItems
-    const el = document.getElementById(
-      'treatmentHistory'
-    ) as HTMLInputElement | null
-    if (el) el.value = treatmentHistoryItems.join(',')
-  }, [treatmentHistoryItems])
+    treatmentHistoryInput = selectedTreatmentConditions
+  }, [selectedTreatmentConditions])
 
   async function sendRegisterTreatmentRequest() {
     // Validate that a therapist has been selected
@@ -138,6 +133,7 @@ export default function RegisterTreatment() {
       setTherapistID('')
       if (issuesInput) issuesInput.value = ''
       if (treatmentHistoryInput) treatmentHistoryInput = []
+      setSelectedTreatmentConditions([])
       if (remarksInput) remarksInput.value = ''
       if (nextVisitInput) nextVisitInput.value = ''
     }
@@ -226,8 +222,10 @@ export default function RegisterTreatment() {
               <TreatmentConditionMultiSelect
                 id="treatment"
                 label="Penanganan"
-                value={treatmentHistoryItems}
-                onChange={(items: string[]) => setTreatmentHistoryItems(items)}
+                value={selectedTreatmentConditions}
+                onChange={(items: string[]) =>
+                  setSelectedTreatmentConditions(items)
+                }
               />
             </div>
             <div className="w-72 space-y-1">


### PR DESCRIPTION
This pull request introduces a reusable multi-select component for selecting treatment conditions, and refactors related forms to use this new component instead of custom checkbox logic. The main goal is to improve code maintainability and user experience by centralizing the multi-select logic and ensuring consistent UI behavior across different parts of the application.

**Component creation and usage refactor:**

* Added a new `TreatmentConditionMultiSelect` component in `selectTreatmentCondition.tsx`, supporting both native `<select multiple>` and checkbox fallback for non-browser environments. This component manages selection state and notifies parent components of changes.
* Updated `treatmentForm.tsx` and `register/page.tsx` to use the new `TreatmentConditionMultiSelect` component, replacing previous custom checkbox implementations. [[1]](diffhunk://#diff-a43b4db15291d8175d8218ea96826fefdc013a54957c11d1b91bee16ea071b88R7) [[2]](diffhunk://#diff-4ec45d4a2decdff6dafabce55dd76eb1651a5696163e2479248c6bbc00325bedL3-R9) [[3]](diffhunk://#diff-4ec45d4a2decdff6dafabce55dd76eb1651a5696163e2479248c6bbc00325bedL262-R231)

**State management improvements:**

* In `treatmentForm.tsx`, added logic to parse the `treatment` prop into an array, and synchronize the multi-select state with a hidden textarea to maintain compatibility with existing form submission logic. [[1]](diffhunk://#diff-a43b4db15291d8175d8218ea96826fefdc013a54957c11d1b91bee16ea071b88R29-R51) [[2]](diffhunk://#diff-a43b4db15291d8175d8218ea96826fefdc013a54957c11d1b91bee16ea071b88R165-R175)
* In `register/page.tsx`, replaced the `MultipleCheckboxes` component with state managed by `TreatmentConditionMultiSelect`, and ensured the selected values are kept in sync with a hidden input for legacy code paths.

These changes streamline the codebase, reduce duplication, and provide a more robust and testable multi-select experience for treatment conditions.