### PR TITLE
Bugfix/Timepicker not working

### DIFF
--- a/src/app/_components/timepicker.tsx
+++ b/src/app/_components/timepicker.tsx
@@ -19,7 +19,7 @@ type TimePickerProps = {
 export default function TimePicker({
   id,
   label,
-  value = null,
+  value,
   onChange,
   step = 15,
   // keep props for compatibility but not used in this simple version
@@ -31,6 +31,7 @@ export default function TimePicker({
 }: TimePickerProps) {
   const generatedId = useId()
   const uid = id ?? generatedId
+  const isControlled = typeof value !== 'undefined'
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const v = e.target.value // "" or "HH:MM" (browser provides HH:MM for type="time")
@@ -50,7 +51,7 @@ export default function TimePicker({
       <input
         id={uid}
         type="time"
-        value={value ?? ''}
+        {...(isControlled ? { value: value ?? '' } : {})}
         onChange={handleChange}
         disabled={disabled}
         min={min ?? undefined}


### PR DESCRIPTION
This pull request updates the `TimePicker` component to better support both controlled and uncontrolled usage patterns in React. The main improvement is that the `value` prop is now only set when it is explicitly provided, which prevents React warnings about switching between controlled and uncontrolled inputs.

Controlled/uncontrolled input handling:

* Added an `isControlled` check to determine if the `TimePicker` should be controlled based on whether the `value` prop is defined. The `value` attribute is now only set on the `<input>` element when the component is controlled, preventing React warnings. [[1]](diffhunk://#diff-0c6474225a02faa3222f581e266653febfc8bf3897be8632a35853588479c061L22-R22) [[2]](diffhunk://#diff-0c6474225a02faa3222f581e266653febfc8bf3897be8632a35853588479c061R34) [[3]](diffhunk://#diff-0c6474225a02faa3222f581e266653febfc8bf3897be8632a35853588479c061L53-R54)…ontrolled state logic