### PR TITLE
Feature/Add 'Penyakit' item to mega menu for disease management

### DIFF
--- a/src/app/_components/megaMenu.tsx
+++ b/src/app/_components/megaMenu.tsx
@@ -16,6 +16,7 @@ import {
   ChevronDownIcon,
   Bars3Icon,
   XMarkIcon,
+  DocumentTextIcon,
 } from '@heroicons/react/24/outline'
 import { HeartIcon } from '@heroicons/react/24/solid'
 import { SquaresPlusIcon, UserGroupIcon } from '@heroicons/react/24/solid'
@@ -41,6 +42,13 @@ const navListMenuItems = [
     description: 'Halaman manajemen terapis',
     icon: UserGroupIcon,
     url: '/therapist',
+    roles: ['super_admin'],
+  },
+  {
+    title: 'Penyakit',
+    description: 'Halaman manajemen penyakit',
+    icon: DocumentTextIcon,
+    url: '/disease',
     roles: ['super_admin'],
   },
   {


### PR DESCRIPTION
This pull request updates the `megaMenu` component by adding a new menu item for disease management, specifically for users with the `super_admin` role. Additionally, it imports the necessary icon for this new menu item.

Menu updates:

* Added a new menu item titled "Penyakit" for disease management, visible only to `super_admin` users, with the `DocumentTextIcon` as its icon and linking to `/disease`.

Icon imports:

* Imported `DocumentTextIcon` from `@heroicons/react/24/outline` to support the new menu item.