### PR TITLE
Bugfix/Clear form fields after successful registration instead of redirecting

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -88,7 +88,11 @@ export default function Register() {
         }
         updatePhoneAt(0, '')
       } catch (e) {
-        // noop: defensive in case hook internals change
+        // Log defensively in case hook internals change, without breaking UX
+        console.error(
+          'Error while clearing phone numbers after successful registration:',
+          e
+        )
       }
 
       if (patientCodeRef.current) patientCodeRef.current.value = ''


### PR DESCRIPTION
This pull request updates the registration flow to improve user experience after a successful registration. Instead of redirecting the user to the login page, the form fields are now cleared, allowing the user to stay on the registration page and potentially register another user.

Key changes to registration behavior:

* After a successful registration, the form fields are cleared instead of redirecting the user to the login page. This includes resetting all input fields, clearing phone numbers (leaving only one empty input), and resetting the patient code reference.