### PR TITLE
Feature/Implement Sign Signature on Patient Register

### DIFF
--- a/src/app/_components/__tests__/signaturePad.test.tsx
+++ b/src/app/_components/__tests__/signaturePad.test.tsx
@@ -35,7 +35,9 @@ describe('SignaturePad Component', () => {
   }
 
   const mockGetContext = jest.fn().mockReturnValue(mockContext)
-  const mockToDataURL = jest.fn().mockReturnValue('data:image/png;base64,mockImage')
+  const mockToDataURL = jest
+    .fn()
+    .mockReturnValue('data:image/png;base64,mockImage')
   const mockSetPointerCapture = jest.fn()
   const mockReleasePointerCapture = jest.fn()
   const mockGetBoundingClientRect = jest.fn().mockReturnValue({
@@ -56,8 +58,10 @@ describe('SignaturePad Component', () => {
     HTMLCanvasElement.prototype.getContext = mockGetContext as any
     HTMLCanvasElement.prototype.toDataURL = mockToDataURL
     HTMLCanvasElement.prototype.setPointerCapture = mockSetPointerCapture
-    HTMLCanvasElement.prototype.releasePointerCapture = mockReleasePointerCapture
-    HTMLCanvasElement.prototype.getBoundingClientRect = mockGetBoundingClientRect
+    HTMLCanvasElement.prototype.releasePointerCapture =
+      mockReleasePointerCapture
+    HTMLCanvasElement.prototype.getBoundingClientRect =
+      mockGetBoundingClientRect
   })
 
   beforeEach(() => {
@@ -70,9 +74,13 @@ describe('SignaturePad Component', () => {
 
     expect(screen.getByText('Tanda Tangan Pasien')).toBeInTheDocument()
     expect(
-      screen.getByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+      screen.getByText(
+        'Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini'
+      )
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /hapus tanda tangan/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /hapus tanda tangan/i })
+    ).toBeInTheDocument()
   })
 
   test('simulates drawing flow and triggers onChange', () => {
@@ -98,14 +106,18 @@ describe('SignaturePad Component', () => {
 
     // Placeholder should be hidden
     expect(
-      screen.queryByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+      screen.queryByText(
+        'Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini'
+      )
     ).not.toBeInTheDocument()
   })
 
   test('clears the signature and triggers callbacks', () => {
     const mockOnChange = jest.fn()
     const mockOnClear = jest.fn()
-    const { container } = render(<SignaturePad onChange={mockOnChange} onClear={mockOnClear} />)
+    const { container } = render(
+      <SignaturePad onChange={mockOnChange} onClear={mockOnClear} />
+    )
     const canvas = container.querySelector('canvas')
     if (!canvas) throw new Error('Canvas not found')
 
@@ -113,7 +125,9 @@ describe('SignaturePad Component', () => {
     fireEvent.pointerDown(canvas, { pointerId: 1, clientX: 50, clientY: 50 })
     fireEvent.pointerUp(canvas, { pointerId: 1 })
     expect(
-      screen.queryByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+      screen.queryByText(
+        'Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini'
+      )
     ).not.toBeInTheDocument()
 
     // Click clear button
@@ -126,14 +140,18 @@ describe('SignaturePad Component', () => {
 
     // Placeholder should be visible again
     expect(
-      screen.getByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+      screen.getByText(
+        'Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini'
+      )
     ).toBeInTheDocument()
   })
 
   test('supports imperative clear ref method', () => {
     const mockOnChange = jest.fn()
     const ref = createRef<SignaturePadRef>()
-    const { container } = render(<SignaturePad ref={ref} onChange={mockOnChange} />)
+    const { container } = render(
+      <SignaturePad ref={ref} onChange={mockOnChange} />
+    )
     const canvas = container.querySelector('canvas')
     if (!canvas) throw new Error('Canvas not found')
 
@@ -141,7 +159,9 @@ describe('SignaturePad Component', () => {
     fireEvent.pointerDown(canvas, { pointerId: 1, clientX: 50, clientY: 50 })
     fireEvent.pointerUp(canvas, { pointerId: 1 })
     expect(
-      screen.queryByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+      screen.queryByText(
+        'Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini'
+      )
     ).not.toBeInTheDocument()
 
     // Call clear imperatively
@@ -152,7 +172,9 @@ describe('SignaturePad Component', () => {
     expect(mockContext.clearRect).toHaveBeenCalled()
     expect(mockOnChange).toHaveBeenLastCalledWith('')
     expect(
-      screen.getByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+      screen.getByText(
+        'Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini'
+      )
     ).toBeInTheDocument()
   })
 

--- a/src/app/_components/__tests__/signaturePad.test.tsx
+++ b/src/app/_components/__tests__/signaturePad.test.tsx
@@ -1,0 +1,178 @@
+import '@testing-library/jest-dom'
+import React, { createRef } from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { SignaturePad, SignaturePadRef } from '../signaturePad'
+
+// Polyfill PointerEvent for JSDOM which lacks native support
+class MockPointerEvent extends MouseEvent {
+  pointerId: number
+  pointerType: string
+  isPrimary: boolean
+
+  constructor(type: string, params: any = {}) {
+    super(type, params)
+    this.pointerId = params.pointerId || 0
+    this.pointerType = params.pointerType || ''
+    this.isPrimary = params.isPrimary || false
+  }
+}
+
+describe('SignaturePad Component', () => {
+  const mockContext = {
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    stroke: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    setTransform: jest.fn(),
+    clearRect: jest.fn(),
+    scale: jest.fn(),
+    lineWidth: 3,
+    lineCap: 'round',
+    lineJoin: 'round',
+    strokeStyle: '#0f172a',
+  }
+
+  const mockGetContext = jest.fn().mockReturnValue(mockContext)
+  const mockToDataURL = jest.fn().mockReturnValue('data:image/png;base64,mockImage')
+  const mockSetPointerCapture = jest.fn()
+  const mockReleasePointerCapture = jest.fn()
+  const mockGetBoundingClientRect = jest.fn().mockReturnValue({
+    left: 10,
+    top: 20,
+    width: 400,
+    height: 220,
+  })
+
+  beforeAll(() => {
+    global.PointerEvent = MockPointerEvent as any
+
+    Object.defineProperty(window, 'devicePixelRatio', {
+      value: 2,
+      configurable: true,
+    })
+
+    HTMLCanvasElement.prototype.getContext = mockGetContext as any
+    HTMLCanvasElement.prototype.toDataURL = mockToDataURL
+    HTMLCanvasElement.prototype.setPointerCapture = mockSetPointerCapture
+    HTMLCanvasElement.prototype.releasePointerCapture = mockReleasePointerCapture
+    HTMLCanvasElement.prototype.getBoundingClientRect = mockGetBoundingClientRect
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('renders with custom label and placeholder text', () => {
+    const mockOnChange = jest.fn()
+    render(<SignaturePad onChange={mockOnChange} />)
+
+    expect(screen.getByText('Tanda Tangan Pasien')).toBeInTheDocument()
+    expect(
+      screen.getByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hapus tanda tangan/i })).toBeInTheDocument()
+  })
+
+  test('simulates drawing flow and triggers onChange', () => {
+    const mockOnChange = jest.fn()
+    const { container } = render(<SignaturePad onChange={mockOnChange} />)
+    const canvas = container.querySelector('canvas')
+    expect(canvas).toBeInTheDocument()
+    if (!canvas) throw new Error('Canvas not found')
+
+    // Start drawing
+    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: 50, clientY: 50 })
+    expect(mockContext.beginPath).toHaveBeenCalled()
+    expect(mockContext.moveTo).toHaveBeenCalledWith(40, 30) // clientX (50) - rect.left (10), clientY (50) - rect.top (20)
+
+    // Moving
+    fireEvent.pointerMove(canvas, { pointerId: 1, clientX: 60, clientY: 70 })
+    expect(mockContext.lineTo).toHaveBeenCalledWith(50, 50) // 60-10, 70-20
+    expect(mockContext.stroke).toHaveBeenCalled()
+
+    // Stop drawing
+    fireEvent.pointerUp(canvas, { pointerId: 1 })
+    expect(mockOnChange).toHaveBeenCalledWith('data:image/png;base64,mockImage')
+
+    // Placeholder should be hidden
+    expect(
+      screen.queryByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+    ).not.toBeInTheDocument()
+  })
+
+  test('clears the signature and triggers callbacks', () => {
+    const mockOnChange = jest.fn()
+    const mockOnClear = jest.fn()
+    const { container } = render(<SignaturePad onChange={mockOnChange} onClear={mockOnClear} />)
+    const canvas = container.querySelector('canvas')
+    if (!canvas) throw new Error('Canvas not found')
+
+    // Draw first to make it non-empty
+    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: 50, clientY: 50 })
+    fireEvent.pointerUp(canvas, { pointerId: 1 })
+    expect(
+      screen.queryByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+    ).not.toBeInTheDocument()
+
+    // Click clear button
+    const clearButton = screen.getByRole('button', { name: /hapus/i })
+    fireEvent.click(clearButton)
+
+    expect(mockContext.clearRect).toHaveBeenCalled()
+    expect(mockOnChange).toHaveBeenLastCalledWith('')
+    expect(mockOnClear).toHaveBeenCalled()
+
+    // Placeholder should be visible again
+    expect(
+      screen.getByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+    ).toBeInTheDocument()
+  })
+
+  test('supports imperative clear ref method', () => {
+    const mockOnChange = jest.fn()
+    const ref = createRef<SignaturePadRef>()
+    const { container } = render(<SignaturePad ref={ref} onChange={mockOnChange} />)
+    const canvas = container.querySelector('canvas')
+    if (!canvas) throw new Error('Canvas not found')
+
+    // Draw first to make it non-empty
+    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: 50, clientY: 50 })
+    fireEvent.pointerUp(canvas, { pointerId: 1 })
+    expect(
+      screen.queryByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+    ).not.toBeInTheDocument()
+
+    // Call clear imperatively
+    act(() => {
+      ref.current?.clear()
+    })
+
+    expect(mockContext.clearRect).toHaveBeenCalled()
+    expect(mockOnChange).toHaveBeenLastCalledWith('')
+    expect(
+      screen.getByText('Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini')
+    ).toBeInTheDocument()
+  })
+
+  test('handles pointerleave and pointercancel to stop drawing', () => {
+    const mockOnChange = jest.fn()
+    const { container } = render(<SignaturePad onChange={mockOnChange} />)
+    const canvas = container.querySelector('canvas')
+    if (!canvas) throw new Error('Canvas not found')
+
+    // Down
+    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: 50, clientY: 50 })
+    // Leave
+    fireEvent.pointerLeave(canvas, { pointerId: 1 })
+    expect(mockOnChange).toHaveBeenCalledWith('data:image/png;base64,mockImage')
+    mockOnChange.mockClear()
+
+    // Down again
+    fireEvent.pointerDown(canvas, { pointerId: 2, clientX: 50, clientY: 50 })
+    // Cancel
+    fireEvent.pointerCancel(canvas, { pointerId: 2 })
+    expect(mockOnChange).toHaveBeenCalledWith('data:image/png;base64,mockImage')
+  })
+})

--- a/src/app/_components/signaturePad.tsx
+++ b/src/app/_components/signaturePad.tsx
@@ -1,0 +1,162 @@
+import { useRef, useState, useEffect, forwardRef, useImperativeHandle } from 'react'
+
+export interface SignaturePadRef {
+  clear: () => void
+}
+
+interface SignaturePadProps {
+  onChange: (base64Image: string) => void
+  onClear?: () => void
+}
+
+export const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
+  ({ onChange, onClear }, ref) => {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null)
+    const [isDrawing, setIsDrawing] = useState(false)
+    const [isEmpty, setIsEmpty] = useState(true)
+
+    // Setup canvas line style context
+    const getCanvasContext = () => {
+      const canvas = canvasRef.current
+      if (!canvas) return null
+      const ctx = canvas.getContext('2d')
+      return ctx
+    }
+
+    // Draw start
+    const startDrawing = (e: React.PointerEvent<HTMLCanvasElement>) => {
+      e.preventDefault()
+      const canvas = canvasRef.current
+      if (!canvas) return
+      const ctx = getCanvasContext()
+      if (!ctx) return
+
+      // Set target capturing for touch/stylus inputs to prevent missing up/leave events
+      canvas.setPointerCapture(e.pointerId)
+
+      const rect = canvas.getBoundingClientRect()
+      const x = e.clientX - rect.left
+      const y = e.clientY - rect.top
+
+      ctx.beginPath()
+      ctx.moveTo(x, y)
+      setIsDrawing(true)
+      setIsEmpty(false)
+    }
+
+    // Draw move
+    const draw = (e: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!isDrawing) return
+      e.preventDefault()
+      const canvas = canvasRef.current
+      if (!canvas) return
+      const ctx = getCanvasContext()
+      if (!ctx) return
+
+      const rect = canvas.getBoundingClientRect()
+      const x = e.clientX - rect.left
+      const y = e.clientY - rect.top
+
+      ctx.lineTo(x, y)
+      ctx.stroke()
+    }
+
+    // Draw stop
+    const stopDrawing = (e: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!isDrawing) return
+      setIsDrawing(false)
+      const canvas = canvasRef.current
+      if (canvas) {
+        // Release captured pointer
+        try {
+          canvas.releasePointerCapture(e.pointerId)
+        } catch (err) {
+          // ignore if already released
+        }
+        onChange(canvas.toDataURL('image/png'))
+      }
+    }
+
+    // Clear canvas
+    const handleClear = () => {
+      const canvas = canvasRef.current
+      if (!canvas) return
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      
+      // Clear scaled coordinates correctly
+      ctx.save()
+      ctx.setTransform(1, 0, 0, 1, 0, 0)
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.restore()
+
+      setIsEmpty(true)
+      onChange('')
+      if (onClear) onClear()
+    }
+
+    // Expose clear function to parent components via ref
+    useImperativeHandle(ref, () => ({
+      clear: handleClear,
+    }))
+
+    // Match canvas resolution to device pixel ratio for crystal clear rendering on iPad/Retina screens
+    useEffect(() => {
+      const canvas = canvasRef.current
+      if (canvas) {
+        const rect = canvas.getBoundingClientRect()
+        const dpr = window.devicePixelRatio || 1
+        
+        // Scale internal backing store width/height by DPR
+        canvas.width = (rect.width || 400) * dpr
+        canvas.height = (rect.height || 220) * dpr
+        
+        const ctx = canvas.getContext('2d')
+        if (ctx) {
+          // Scale context drawing matching backing store scaling
+          ctx.scale(dpr, dpr)
+          ctx.lineWidth = 3
+          ctx.lineCap = 'round'
+          ctx.lineJoin = 'round'
+          ctx.strokeStyle = '#0f172a' // slate-900
+        }
+      }
+    }, [])
+
+    return (
+      <div className="w-full">
+        <label className="mb-1 block text-sm font-medium text-slate-600 dark:text-slate-300">
+          Tanda Tangan Pasien
+        </label>
+        <div className="relative overflow-hidden rounded-lg border border-slate-200 bg-white/50 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/50">
+          <canvas
+            ref={canvasRef}
+            onPointerDown={startDrawing}
+            onPointerMove={draw}
+            onPointerUp={stopDrawing}
+            onPointerLeave={stopDrawing}
+            onPointerCancel={stopDrawing}
+            className="block h-[220px] w-full cursor-crosshair touch-none bg-slate-50 dark:bg-slate-950"
+            style={{ touchAction: 'none' }}
+          />
+          {isEmpty && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm italic text-slate-400">
+              Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini
+            </div>
+          )}
+        </div>
+        <div className="mt-2 flex justify-end">
+          <button
+            type="button"
+            onClick={handleClear}
+            className="rounded border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-600 transition hover:bg-red-100 hover:text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400 dark:hover:bg-red-950/40"
+          >
+            Hapus Tanda Tangan
+          </button>
+        </div>
+      </div>
+    )
+  }
+)
+
+SignaturePad.displayName = 'SignaturePad'

--- a/src/app/_components/signaturePad.tsx
+++ b/src/app/_components/signaturePad.tsx
@@ -1,4 +1,10 @@
-import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle } from 'react'
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  forwardRef,
+  useImperativeHandle,
+} from 'react'
 
 export interface SignaturePadRef {
   clear: () => void
@@ -83,7 +89,7 @@ export const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
       if (!canvas) return
       const ctx = canvas.getContext('2d')
       if (!ctx) return
-      
+
       // Clear scaled coordinates correctly
       ctx.save()
       ctx.setTransform(1, 0, 0, 1, 0, 0)
@@ -106,11 +112,11 @@ export const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
       if (canvas) {
         const rect = canvas.getBoundingClientRect()
         const dpr = window.devicePixelRatio || 1
-        
+
         // Scale internal backing store width/height by DPR
         canvas.width = (rect.width || 400) * dpr
         canvas.height = (rect.height || 220) * dpr
-        
+
         const ctx = canvas.getContext('2d')
         if (ctx) {
           // Scale context drawing matching backing store scaling
@@ -125,23 +131,25 @@ export const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
 
     return (
       <div className="w-full">
-        <label className="mb-1 block text-sm font-medium text-slate-600 dark:text-slate-300">
+        <label className="text-slate-600 dark:text-slate-300 mb-1 block text-sm font-medium">
           Tanda Tangan Pasien
         </label>
-        <div className="relative overflow-hidden rounded-lg border border-slate-200 bg-white/50 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/50">
-          <canvas aria-label="Tanda Tangan Pasien"
+        <div className="border-slate-200 dark:border-slate-800 dark:bg-slate-900/50 relative overflow-hidden rounded-lg border bg-white/50 backdrop-blur-sm">
+          <canvas
+            aria-label="Tanda Tangan Pasien"
             ref={canvasRef}
             onPointerDown={startDrawing}
             onPointerMove={draw}
             onPointerUp={stopDrawing}
             onPointerLeave={stopDrawing}
             onPointerCancel={stopDrawing}
-            className="block h-[220px] w-full cursor-crosshair touch-none bg-slate-50 dark:bg-slate-950"
+            className="bg-slate-50 dark:bg-slate-950 block h-[220px] w-full cursor-crosshair touch-none"
             style={{ touchAction: 'none' }}
           />
           {isEmpty && (
-            <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm italic text-slate-400">
-              Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di sini
+            <div className="text-slate-400 pointer-events-none absolute inset-0 flex items-center justify-center text-sm italic">
+              Gunakan mouse, sentuhan, atau Apple Pencil untuk tanda tangan di
+              sini
             </div>
           )}
         </div>
@@ -149,7 +157,7 @@ export const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
           <button
             type="button"
             onClick={handleClear}
-            className="rounded border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-600 transition hover:bg-red-100 hover:text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400 dark:hover:bg-red-950/40"
+            className="dark:bg-red-950/20 dark:hover:bg-red-950/40 rounded border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-600 transition hover:bg-red-100 hover:text-red-700 dark:border-red-900/50 dark:text-red-400"
           >
             Hapus Tanda Tangan
           </button>

--- a/src/app/_components/signaturePad.tsx
+++ b/src/app/_components/signaturePad.tsx
@@ -5,7 +5,7 @@ export interface SignaturePadRef {
 }
 
 interface SignaturePadProps {
-  onChange: (base64Image: string) => void
+  onChange: (dataUrl: string) => void
   onClear?: () => void
 }
 

--- a/src/app/_components/signaturePad.tsx
+++ b/src/app/_components/signaturePad.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, forwardRef, useImperativeHandle } from 'react'
+import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle } from 'react'
 
 export interface SignaturePadRef {
   clear: () => void

--- a/src/app/_components/signaturePad.tsx
+++ b/src/app/_components/signaturePad.tsx
@@ -129,7 +129,7 @@ export const SignaturePad = forwardRef<SignaturePadRef, SignaturePadProps>(
           Tanda Tangan Pasien
         </label>
         <div className="relative overflow-hidden rounded-lg border border-slate-200 bg-white/50 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/50">
-          <canvas
+          <canvas aria-label="Tanda Tangan Pasien"
             ref={canvasRef}
             onPointerDown={startDrawing}
             onPointerMove={draw}

--- a/src/app/_components/treatmentRow.tsx
+++ b/src/app/_components/treatmentRow.tsx
@@ -83,7 +83,7 @@ export default function Treatment({
       }
     }
     fetchTherapistIdFallback()
-  }, [isTherapistRole, currentUserId, currentTherapistIdState])
+  }, [isTherapistRole, currentUserId, currentTherapistIdState, router])
 
   // Check if current user can edit this treatment
   // Admins can edit all treatments

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -8,6 +8,7 @@ import { apiFetch } from '../_functions/apiFetch'
 import { DiseaseMultiSelect } from '../_components/selectDisease'
 import { extractErrorMessage } from '../_functions/errorMessage'
 import Swal from 'sweetalert2'
+import { SignaturePad, type SignaturePadRef } from '../_components/signaturePad'
 
 type GenderValue = 'male' | 'female' | ''
 
@@ -36,6 +37,8 @@ export default function Register() {
   const [showPatientCode, setShowPatientCode] = useState(false)
   const patientCodeRef = useRef<HTMLInputElement | null>(null)
   const [termsAccepted, setTermsAccepted] = useState(false)
+  const [signature, setSignature] = useState('')
+  const signaturePadRef = useRef<SignaturePadRef | null>(null)
 
   async function sendRegisterRequest() {
     const validationError = validateRegistration(
@@ -58,7 +61,8 @@ export default function Register() {
       healthHistory,
       surgeryHistory,
       phoneNumbers,
-      patientCodeRef.current?.value || ''
+      patientCodeRef.current?.value || '',
+      signature
     )
 
     const result = await submitRegistration(payload)
@@ -80,6 +84,8 @@ export default function Register() {
       setHealthHistory([])
       setShowPatientCode(false)
       setTermsAccepted(false)
+      setSignature('')
+      signaturePadRef.current?.clear()
 
       // Clear phone inputs: remove extras and leave a single empty input
       try {
@@ -193,6 +199,8 @@ export default function Register() {
           inputRef={patientCodeRef}
         />
 
+        <SignaturePad ref={signaturePadRef} onChange={setSignature} />
+
         <div className={styles.ctas}>
           <a
             className={
@@ -245,7 +253,8 @@ function buildRegistrationPayload(
   healthHistory: string[],
   surgeryHistory: string,
   phoneNumbers: string[],
-  patientCode: string
+  patientCode: string,
+  signature: string
 ) {
   const validPhones = phoneNumbers.filter((p) => p && p.trim())
   return {
@@ -258,6 +267,7 @@ function buildRegistrationPayload(
     surgery_history: surgeryHistory,
     phone_number: validPhones,
     patient_code: patientCode,
+    signature: signature,
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new `SignaturePad` component to the registration page, allowing users to provide and clear their signatures as part of the registration process. The signature is captured as a base64-encoded image and included in the registration payload. The most important changes are:

**Feature: Signature Pad Integration**
* Added a reusable `SignaturePad` React component (`src/app/_components/signaturePad.tsx`) that supports drawing, clearing, and exporting the signature as a base64 image. It handles high-DPI screens and exposes a `clear` method via ref.
* Integrated `SignaturePad` into the registration form (`src/app/register/page.tsx`), storing the signature in state and resetting it on form clear. [[1]](diffhunk://#diff-c1ff141b4c2bc7241e40eb863a9451c6212795bde3ea9e7c074d28a2af202e4fR40-R41) [[2]](diffhunk://#diff-c1ff141b4c2bc7241e40eb863a9451c6212795bde3ea9e7c074d28a2af202e4fR202-R203) [[3]](diffhunk://#diff-c1ff141b4c2bc7241e40eb863a9451c6212795bde3ea9e7c074d28a2af202e4fR87-R88)

**Registration Payload Update**
* Updated the registration payload builder and submission logic to include the signature image data in the payload sent to the backend. [[1]](diffhunk://#diff-c1ff141b4c2bc7241e40eb863a9451c6212795bde3ea9e7c074d28a2af202e4fL61-R65) [[2]](diffhunk://#diff-c1ff141b4c2bc7241e40eb863a9451c6212795bde3ea9e7c074d28a2af202e4fL248-R257) [[3]](diffhunk://#diff-c1ff141b4c2bc7241e40eb863a9451c6212795bde3ea9e7c074d28a2af202e4fR270)

**Imports and Typings**
* Imported `SignaturePad` and its ref type into the registration page for proper type safety and usage.