### PR TITLE
Bugfix/Mega Menu is not Responsive in Mobile

### DIFF
--- a/src/app/_components/megaMenu.tsx
+++ b/src/app/_components/megaMenu.tsx
@@ -177,56 +177,76 @@ function NavListMenu() {
 
   return (
     <React.Fragment>
-      <Menu
-        open={isMenuOpen}
-        handler={setIsMenuOpen}
-        offset={{ mainAxis: 20 }}
-        placement="bottom"
-      >
-        {(userRole === 'super_admin' || userRole === 'therapist') && (
-          <MenuHandler>
-            <Typography as="div" variant="small" className="font-medium">
-              <ListItem
-                className="flex items-center gap-2 py-2 pr-4 font-medium text-gray-900"
-                selected={isMenuOpen || isMobileMenuOpen}
-                onClick={() => setIsMobileMenuOpen((cur) => !cur)}
-                placeholder={undefined}
-                onPointerEnterCapture={undefined}
-                onPointerLeaveCapture={undefined}
-                onResize={undefined}
-                onResizeCapture={undefined}
-              >
-                Menu
-                <ChevronDownIcon
-                  strokeWidth={2.5}
-                  className={`hidden size-3 transition-transform lg:block ${
-                    isMenuOpen ? 'rotate-180' : ''
-                  }`}
-                />
-                <ChevronDownIcon
-                  strokeWidth={2.5}
-                  className={`block size-3 transition-transform lg:hidden ${
-                    isMobileMenuOpen ? 'rotate-180' : ''
-                  }`}
-                />
-              </ListItem>
-            </Typography>
-          </MenuHandler>
-        )}
-        <MenuList
-          className="hidden max-w-screen-xl rounded-xl lg:block"
-          placeholder={undefined}
-          onPointerEnterCapture={undefined}
-          onPointerLeaveCapture={undefined}
-          onResize={undefined}
-          onResizeCapture={undefined}
+      {/* Desktop Menu */}
+      <div className="hidden lg:block">
+        <Menu
+          open={isMenuOpen}
+          handler={setIsMenuOpen}
+          offset={{ mainAxis: 20 }}
+          placement="bottom"
         >
-          <ul className="grid grid-cols-3 gap-y-2 outline-none outline-0">
-            {renderItems}
-          </ul>
-        </MenuList>
-      </Menu>
+          {(userRole === 'super_admin' || userRole === 'therapist') && (
+            <MenuHandler>
+              <Typography as="div" variant="small" className="font-medium">
+                <ListItem
+                  className="flex items-center gap-2 py-2 pr-4 font-medium text-gray-900"
+                  selected={isMenuOpen}
+                  placeholder={undefined}
+                  onPointerEnterCapture={undefined}
+                  onPointerLeaveCapture={undefined}
+                  onResize={undefined}
+                  onResizeCapture={undefined}
+                >
+                  Menu
+                  <ChevronDownIcon
+                    strokeWidth={2.5}
+                    className={`hidden size-3 transition-transform lg:block ${
+                      isMenuOpen ? 'rotate-180' : ''
+                    }`}
+                  />
+                </ListItem>
+              </Typography>
+            </MenuHandler>
+          )}
+          <MenuList
+            className="hidden max-w-screen-xl rounded-xl lg:block"
+            placeholder={undefined}
+            onPointerEnterCapture={undefined}
+            onPointerLeaveCapture={undefined}
+            onResize={undefined}
+            onResizeCapture={undefined}
+          >
+            <ul className="grid grid-cols-3 gap-y-2 outline-none outline-0">
+              {renderItems}
+            </ul>
+          </MenuList>
+        </Menu>
+      </div>
+
+      {/* Mobile Menu */}
       <div className="block lg:hidden">
+        {(userRole === 'super_admin' || userRole === 'therapist') && (
+          <Typography as="div" variant="small" className="font-medium">
+            <ListItem
+              className="flex items-center gap-2 py-2 pr-4 font-medium text-gray-900"
+              selected={isMobileMenuOpen}
+              onClick={() => setIsMobileMenuOpen((cur) => !cur)}
+              placeholder={undefined}
+              onPointerEnterCapture={undefined}
+              onPointerLeaveCapture={undefined}
+              onResize={undefined}
+              onResizeCapture={undefined}
+            >
+              Menu
+              <ChevronDownIcon
+                strokeWidth={2.5}
+                className={`block size-3 transition-transform lg:hidden ${
+                  isMobileMenuOpen ? 'rotate-180' : ''
+                }`}
+              />
+            </ListItem>
+          </Typography>
+        )}
         <Collapse open={isMobileMenuOpen}>{renderItems}</Collapse>
       </div>
     </React.Fragment>


### PR DESCRIPTION
This pull request refactors the navigation menu in `megaMenu.tsx` to improve the separation between desktop and mobile menu experiences, and fixes the menu toggle logic for each. The desktop and mobile menus are now rendered separately, and the menu toggle and chevron icon behavior has been corrected for each context.

**Desktop and Mobile Menu Separation**
- The desktop menu is now wrapped in a `div` with `lg:block` and is only visible on large screens, while the mobile menu is wrapped in a `div` with `block lg:hidden` and is only visible on small screens. [[1]](diffhunk://#diff-45a1809765e781ec84df82f6f76ffb1fecc891671140091e1653339054d2fe4fR180-R181) [[2]](diffhunk://#diff-45a1809765e781ec84df82f6f76ffb1fecc891671140091e1653339054d2fe4fR224-R249)

**Menu Toggle Logic Fixes**
- The `selected` prop for the desktop menu now only depends on `isMenuOpen`, not the mobile state. The mobile menu uses its own `isMobileMenuOpen` state, ensuring toggling works independently for each menu. [[1]](diffhunk://#diff-45a1809765e781ec84df82f6f76ffb1fecc891671140091e1653339054d2fe4fL191-R193) [[2]](diffhunk://#diff-45a1809765e781ec84df82f6f76ffb1fecc891671140091e1653339054d2fe4fR224-R249)
- The chevron icon for expanding/collapsing is now only rendered in the mobile menu, and rotates based on the mobile menu state. [[1]](diffhunk://#diff-45a1809765e781ec84df82f6f76ffb1fecc891671140091e1653339054d2fe4fL206-L211) [[2]](diffhunk://#diff-45a1809765e781ec84df82f6f76ffb1fecc891671140091e1653339054d2fe4fR224-R249)

**Role-Based Mobile Menu Access**
- The mobile menu toggle is only rendered for users with the `'super_admin'` or `'therapist'` roles, restricting access appropriately.

These changes ensure a more robust, accessible, and role-aware navigation experience across devices.